### PR TITLE
Keep dependencies as dependencies in cjs & esm builds, do not bundle …

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,7 @@ import flow from 'rollup-plugin-flow'
 import commonjs from 'rollup-plugin-commonjs'
 import uglify from 'rollup-plugin-uglify'
 import replace from 'rollup-plugin-replace'
+import pkg from './package.json'
 
 const minify = process.env.MINIFY
 const format = process.env.FORMAT
@@ -41,7 +42,12 @@ export default {
     },
     output
   ),
-  external: [],
+  external: umd
+    ? []
+    : [
+        ...Object.keys(pkg.dependencies || {}),
+        ...Object.keys(pkg.peerDependencies || {})
+      ],
   plugins: [
     resolve({ jsnext: true, main: true }),
     flow(),


### PR DESCRIPTION
before 867 bytes
after 595 bytes 💰 😉 