### PR TITLE
Use `form.getState()` directly instead of using subscriptions.

### DIFF
--- a/src/decorator.js
+++ b/src/decorator.js
@@ -25,18 +25,9 @@ const createDecorator = (
   // Save original submit function
   const originalSubmit = form.submit
 
-  // Subscribe to errors, and keep a local copy of them
-  let state: { errors?: Object, submitErrors?: Object } = {}
-  const unsubscribe = form.subscribe(
-    nextState => {
-      state = nextState
-    },
-    { errors: true, submitErrors: true }
-  )
-
   // What to do after submit
   const afterSubmit = () => {
-    const { errors, submitErrors } = state
+    const { errors, submitErrors } = form.getState()
     if (errors && Object.keys(errors).length) {
       focusOnFirstError(errors)
     } else if (submitErrors && Object.keys(submitErrors).length) {
@@ -58,7 +49,6 @@ const createDecorator = (
   }
 
   return () => {
-    unsubscribe()
     form.submit = originalSubmit
   }
 }


### PR DESCRIPTION
Hi :),

I was running into timing issues on async error handling (with final-form `4.18.6` and react-final-form `6.3.3`). (The promise in `onSubmit` would resolve before / at the same time the subscription callback fires and would compare against a stale state. I'm not sure why the subscription is needed because we have access to the form state directly with `getState()`.

This pull request adresses the issue of a potential stale state.
