### PR TITLE
Add TypeScript declaration files to published package

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -50,7 +50,7 @@ export default {
       andTest: series.nps('build', 'test.size')
     },
     copyTypes: {
-      description: 'Copy TypeScript declaration files to dist',
+      description: 'Generate TypeScript declaration files to dist',
       script: 'tsc --declaration --emitDeclarationOnly --outDir dist'
     },
     docs: {

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -17,7 +17,7 @@ export default {
     },
     build: {
       description: 'delete the dist directory and run all builds',
-      default: series(rimraf('dist'), 'nps build.rollup'),
+      default: series(rimraf('dist'), 'nps build.rollup', 'nps copyTypes'),
       rollup: {
         description: 'Run all rollup builds sequentially',
         default: series.nps(
@@ -48,6 +48,10 @@ export default {
         }
       },
       andTest: series.nps('build', 'test.size')
+    },
+    copyTypes: {
+      description: 'Copy TypeScript declaration files to dist',
+      script: 'tsc --declaration --emitDeclarationOnly --outDir dist'
     },
     docs: {
       description: 'Generates table of contents in README',

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "jsnext:main": "dist/final-form-focus.es.js",
   "module": "dist/final-form-focus.es.js",
   "type": "module",
+  "typings": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
**Problem:**
The package has TypeScript source files but does not publish .d.ts declaration files to npm. Users installing from npm get no type information.

**Solution:**
1. Add `typings` field to package.json pointing to `dist/index.d.ts`
2. Add `copyTypes` script to package-scripts.js to generate TypeScript declarations
3. Include `copyTypes` in the `build.default` series

**Pattern:**
Matches the approach used successfully in other final-form packages:
- final-form-calculate
- final-form-submit-listener
- final-form-arrays
- react-final-form

**Testing:**
The build changes follow the exact pattern from final-form-calculate (which successfully publishes types). The TypeScript compiler will generate declaration files during the build process.

**Impact:**
After publishing, TypeScript users will get proper type checking and IntelliSense when using this package.

Addresses the systemic issue of TypeScript types not being published across the final-form ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TypeScript declaration files are now generated and included with the package, enabling full type support and improved IDE assistance.
  * The build process now produces and publishes these declaration files automatically, and the package exposes a typings entry so consumers can use the shipped types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->